### PR TITLE
Improve pacman handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ Run the script directly from a terminal:
 bash generate_system_report.sh
 ```
 
-It checks for several optional helper utilities and offers to install them via `pacman`
-if missing. A report file will be created in the current directory named
-`system_report_<hostname>_<timestamp>.txt`.
+It checks for several optional helper utilities and offers to install them via `pacman` if missing. A report file will be created in the current directory named `system_report_<hostname>_<timestamp>.txt`.
+
+## Prerequisites
+
+The script assumes an Arch Linux environment with the `pacman` package manager
+available. If `pacman` cannot be found, package listings and automatic
+installation of optional tools are skipped. Installing packages requires root
+privileges, so run the script as `root` or ensure `sudo` is configured.
 
 ## Information Collected
 


### PR DESCRIPTION
## Summary
- check that `pacman` exists at startup
- only install packages when `pacman` is available
- use sudo only if not already root
- skip package listing sections when `pacman` is missing
- document new prerequisites

## Testing
- `bash -n generate_system_report.sh`
- `shellcheck generate_system_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_68527f922d18832faedb8385bc7dcf07