### PR TITLE
Add Ubuntu system report script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,41 @@
 # System Report Generation Script
 
-This repository contains a single shell script, `generate_system_report.sh`,
-which builds a detailed text report describing many aspects of an Arch Linux
-system. The script can run with only standard utilities, but installing a few
-optional tools allows it to gather extra information.
+This repository contains shell scripts to generate detailed system reports.
+`generate_system_report.sh` targets Arch Linux systems, while
+`generate_ubuntu_report.sh` performs the same tasks for Ubuntu and
+Ubuntu-based distributions. The scripts can run with only standard utilities,
+but installing a few optional tools allows them to gather extra information.
 
 ## Usage
 
-Run the script directly from a terminal:
+Run either script directly from a terminal:
 
 ```bash
+# For Arch Linux
 bash generate_system_report.sh
+
+# For Ubuntu
+bash generate_ubuntu_report.sh
 ```
 
-It checks for several optional helper utilities and offers to install them via `pacman` if missing. A report file will be created in the current directory named `system_report_<hostname>_<timestamp>.txt`.
+Each script checks for several optional helper utilities and offers to install
+them if possible. A report file will be created in the current directory named
+`system_report_<hostname>_<timestamp>.txt`.
 
 ## Prerequisites
 
-The script assumes an Arch Linux environment with the `pacman` package manager
-available. If `pacman` cannot be found, package listings and automatic
-installation of optional tools are skipped. Installing packages requires root
-privileges, so run the script as `root` or ensure `sudo` is configured.
+`generate_system_report.sh` assumes an Arch Linux environment with the `pacman`
+package manager available. If `pacman` cannot be found, package listings and
+automatic installation of optional tools are skipped.
+
+`generate_ubuntu_report.sh` expects an Ubuntu system with `apt-get` available.
+If `apt-get` cannot be found, package listings and automatic installation of
+optional tools are skipped. Installing packages requires root privileges, so
+run the script as `root` or ensure `sudo` is configured.
 
 ## Information Collected
 
-The generated report may include the following sections:
+The generated reports may include the following sections:
 
 - Overall system summary from `inxi`
 - CPU details via `lscpu`
@@ -35,8 +46,10 @@ The generated report may include the following sections:
 - Kernel and OS release information
 - Disk usage from `df`
 - Running services from `systemctl`
-- Packages installed by `pacman` (all, explicit, foreign, and orphaned)
-- Pending security updates with `arch-audit`
+- Packages installed by the system package manager
+- Manually installed packages
+- Packages that can be autoremoved
+- Pending package updates (and security status on Ubuntu if available)
 
 Sections that rely on optional commands will be skipped if a tool is not
 available.
@@ -49,10 +62,11 @@ To generate a complete report, these packages should be installed:
 - `inxi` for a high-level system summary
 - `pciutils` to list PCI devices
 - `usbutils` to list USB devices
-- `arch-audit` to check for security updates
+- `arch-audit` on Arch to check for security updates
+- `update-notifier-common` on Ubuntu for `ubuntu-security-status`
 
-The script will prompt to install any missing optional packages automatically, but you can
-decline and run with limited output.
+The scripts will prompt to install any missing optional packages automatically,
+but you can decline and run with limited output.
 
 ## License
 

--- a/generate_ubuntu_report.sh
+++ b/generate_ubuntu_report.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Verify apt-get exists
+if ! command -v apt-get &> /dev/null; then
+  echo "apt-get not found. Package-related sections will be skipped."
+  HAS_APT=0
+else
+  HAS_APT=1
+  if (( EUID == 0 )); then
+    APT_CMD="apt-get"
+  else
+    APT_CMD="sudo apt-get"
+  fi
+fi
+
+# Define optional packages and commands
+declare -A OPTIONAL_TOOLS=(
+  [hostname]="inetutils"
+  [inxi]="inxi"
+  [lspci]="pciutils"
+  [lsusb]="usbutils"
+  [ubuntu-security-status]="update-notifier-common"
+)
+
+MISSING_PKGS=()
+
+# Check for optional commands
+for CMD in "${!OPTIONAL_TOOLS[@]}"; do
+  if ! command -v "$CMD" &> /dev/null; then
+    echo "Missing optional tool: $CMD"
+    MISSING_PKGS+=("${OPTIONAL_TOOLS[$CMD]}")
+  fi
+done
+
+# Prompt to install missing packages when apt-get is available
+if (( HAS_APT )) && [[ ${#MISSING_PKGS[@]} -gt 0 ]]; then
+  echo -e "\nThe following optional packages are missing:"
+  echo "${MISSING_PKGS[@]}"
+  read -rp "Would you like to install them now? [Y/n]: " REPLY
+  REPLY=${REPLY,,}
+  if [[ "$REPLY" =~ ^(y|yes)?$ ]]; then
+    $APT_CMD update
+    $APT_CMD install -y "${MISSING_PKGS[@]}"
+  else
+    echo "Continuing without installing missing packages. Some information may be skipped."
+  fi
+elif [[ ${#MISSING_PKGS[@]} -gt 0 ]]; then
+  echo "The following optional packages are missing but cannot be installed automatically:"
+  echo "${MISSING_PKGS[@]}"
+fi
+
+# Safely get hostname fallback
+HOST=$(command -v hostname &> /dev/null && hostname || echo "unknown-host")
+
+REPORT_FILE="system_report_${HOST}_$(date +%Y%m%d_%H%M%S).txt"
+
+echo "Generating system report..."
+{
+  echo "======================"
+  echo " System Information"
+  echo "======================"
+  command -v inxi &> /dev/null && inxi -Faz --no-host || echo "inxi not installed"
+
+  echo -e "\n======================"
+  echo " CPU Information"
+  echo "======================"
+  lscpu
+
+  echo -e "\n======================"
+  echo " Memory Information"
+  echo "======================"
+  free -h
+
+  echo -e "\n======================"
+  echo " Block Devices"
+  echo "======================"
+  lsblk
+
+  echo -e "\n======================"
+  echo " PCI Devices"
+  echo "======================"
+  command -v lspci &> /dev/null && lspci -v || echo "lspci not installed"
+
+  echo -e "\n======================"
+  echo " USB Devices"
+  echo "======================"
+  command -v lsusb &> /dev/null && lsusb || echo "lsusb not installed"
+
+  echo -e "\n======================"
+  echo " Kernel & OS"
+  echo "======================"
+  uname -a
+  cat /etc/os-release
+
+  echo -e "\n======================"
+  echo " Disk Usage"
+  echo "======================"
+  df -h
+
+  echo -e "\n======================"
+  echo " Active Services"
+  echo "======================"
+  systemctl list-units --type=service --state=running
+
+  echo -e "\n======================"
+  echo " All Installed Packages"
+  echo "======================"
+  if (( HAS_APT )); then
+    dpkg-query -W -f='${binary:Package}\t${Version}\n'
+  else
+    echo "apt-get not installed"
+  fi
+
+  echo -e "\n======================"
+  echo " Manually Installed Packages"
+  echo "======================"
+  if (( HAS_APT )); then
+    apt-mark showmanual
+  else
+    echo "apt-get not installed"
+  fi
+
+  echo -e "\n======================"
+  echo " Orphaned Packages"
+  echo "======================"
+  if (( HAS_APT )); then
+    apt-get -s autoremove | awk '/^Remv/ {print $2}' || echo "No orphaned packages found."
+  else
+    echo "apt-get not installed"
+  fi
+
+  echo -e "\n======================"
+  echo " Pending Package Updates"
+  echo "======================"
+  if (( HAS_APT )); then
+    apt list --upgradable 2>/dev/null
+    command -v ubuntu-security-status &> /dev/null && ubuntu-security-status
+  else
+    echo "apt-get not installed"
+  fi
+
+} > "$REPORT_FILE"
+
+echo "Report saved to: $REPORT_FILE"


### PR DESCRIPTION
## Summary
- add `generate_ubuntu_report.sh` to gather information on Ubuntu systems
- update README with usage notes for both Arch and Ubuntu variants

## Testing
- `shellcheck generate_ubuntu_report.sh generate_system_report.sh`
- `bash generate_ubuntu_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_685281c5f4c4832f96e26cd19c70c310