### PR TITLE
Fix lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Each script checks for several optional helper utilities and offers to install
 them if possible. A report file will be created in the current directory named
 `system_report_<hostname>_<timestamp>.txt`.
 
+All scripts use `#!/usr/bin/env bash` and enable `set -euo pipefail` to abort on
+errors and undefined variables.
+
 ## Prerequisites
 
 `generate_arch_report.sh` expects an Arch Linux environment with the `pacman`

--- a/generate_arch_report.sh
+++ b/generate_arch_report.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # Verify pacman exists
 if ! command -v pacman &> /dev/null; then

--- a/generate_fedora_report.sh
+++ b/generate_fedora_report.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # Verify dnf exists
 if ! command -v dnf &> /dev/null; then

--- a/generate_ubuntu_report.sh
+++ b/generate_ubuntu_report.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # Verify apt-get exists
 if ! command -v apt-get &> /dev/null; then


### PR DESCRIPTION
## Summary
- enforce strict bash mode in scripts
- document strict mode in README

## Testing
- `shellcheck generate_arch_report.sh generate_ubuntu_report.sh generate_fedora_report.sh`
- `markdownlint README.md`
- `bash -n generate_arch_report.sh generate_ubuntu_report.sh generate_fedora_report.sh`

------
https://chatgpt.com/codex/tasks/task_e_685287be0938832f84f693a3bd960e4a